### PR TITLE
Add Pie Chart Visualization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,10 @@
       "version": "0.0.0",
       "dependencies": {
         "@vitejs/plugin-react": "^4.2.1",
+        "chart.js": "^4.4.2",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
+        "react-chartjs-2": "^5.2.0",
         "react-dom": "^18.2.0",
         "vite": "^5.1.4"
       },
@@ -855,6 +857,11 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.2.tgz",
+      "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw=="
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1546,6 +1553,17 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.2.tgz",
+      "integrity": "sha512-6GD7iKwFpP5kbSD4MeRRRlTnQvxfQREy36uEtm1hzHzcOqwWx0YEHuspuoNlslu+nciLIB7fjjsHkUv/FzFcOg==",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/color-convert": {
@@ -3890,6 +3908,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.2.0.tgz",
+      "integrity": "sha512-98iN5aguJyVSxp5U3CblRLH67J8gkfyGNbiK3c+l1QI/G4irHMPQw44aEPmjVag+YKTyQ260NcF82GTQ3bdscA==",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,10 @@
   },
   "dependencies": {
     "@vitejs/plugin-react": "^4.2.1",
+    "chart.js": "^4.4.2",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
+    "react-chartjs-2": "^5.2.0",
     "react-dom": "^18.2.0",
     "vite": "^5.1.4"
   },

--- a/src/components/Overview.jsx
+++ b/src/components/Overview.jsx
@@ -2,13 +2,17 @@ import React, { useState } from 'react';
 import StockList from './StockList';
 import Header from './Header';
 import AddStockButton from './AddStockButton';
+import PieChart from './PieChart';
 
 function Overview() {
   // TODO: read these from a db or have some user saved state
   const [stocks, setStocks] = useState([
     { ticker: 'VOO', quantity: 5, value: 500 },
     { ticker: 'V', quantity: 10, value: 23 },
-    { ticker: 'MC', quantity: 0, value: 400 },
+    { ticker: 'MC', quantity: 5, value: 400 },
+    { ticker: 'GOOG', quantity: 5, value: 500 },
+    { ticker: 'EBAY', quantity: 10, value: 23 },
+    { ticker: 'MCO', quantity: 5, value: 400 },
   ]);
 
   // TODO: Make this a global list, potentially from a file too
@@ -38,6 +42,7 @@ function Overview() {
         Total:
         {totalValue}
       </p>
+      <PieChart stocks={stocks} />
     </>
   );
 }

--- a/src/components/PieChart.jsx
+++ b/src/components/PieChart.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Pie } from 'react-chartjs-2';
+import {
+  ArcElement, Chart as ChartJS, Colors, Legend, Tooltip,
+} from 'chart.js';
+import PropTypes from 'prop-types';
+import getStockValue from '../utils/TotalStockValueUtil';
+
+ChartJS.register(ArcElement);
+ChartJS.register(Colors);
+ChartJS.register(Tooltip);
+ChartJS.register(Legend);
+
+function PieChart({ stocks }) {
+  const sortedStocks = stocks.slice().sort((a, b) => getStockValue(b) - getStockValue(a));
+  // Extracting labels and data for the chart
+  const sortedLabels = sortedStocks.map((stock) => stock.ticker);
+  const sortedValues = sortedStocks.map((stock) => getStockValue(stock));
+
+  const data = {
+    labels: sortedLabels,
+    datasets: [
+      {
+        data: sortedValues,
+      },
+    ],
+  };
+
+  const options = {
+    plugins: {
+      tooltip: {
+        enabled: true,
+        callbacks: {
+          label(context) {
+            const labelIndex = context.dataIndex;
+            return `${sortedLabels[labelIndex]}: ${sortedValues[labelIndex]}`;
+          },
+        },
+      },
+      legend: {
+        enabled: true,
+        position: 'right',
+        align: 'right',
+      },
+      colors: {
+        enabled: true,
+      },
+    },
+  };
+
+  return <Pie data={data} options={options} />;
+}
+
+PieChart.propTypes = {
+  stocks: PropTypes.arrayOf(
+    PropTypes.shape({
+      ticker: PropTypes.string.isRequired,
+      quantity: PropTypes.number.isRequired,
+      value: PropTypes.number.isRequired,
+    }),
+  ).isRequired,
+};
+
+export default PieChart;

--- a/src/utils/TotalStockValueUtil.js
+++ b/src/utils/TotalStockValueUtil.js
@@ -1,0 +1,6 @@
+// Function to calculate a stocks total value given a quantity and value
+function getStockValue(stock) {
+  return stock.quantity * stock.value;
+}
+
+export default getStockValue;


### PR DESCRIPTION
Show a live pie chart detailing the breakdown of each components relative makeup of the overall portfolio. 
The colors are a bit broken, but we add a legend, a hover tooltip, and a default color palette. 

We can add the percentage make up onto the piechart later.
Styling also need to happen later.