### PR TITLE
Add Percentage computation to Pie Chart

### DIFF
--- a/src/components/PieChart.jsx
+++ b/src/components/PieChart.jsx
@@ -33,7 +33,9 @@ function PieChart({ stocks }) {
         callbacks: {
           label(context) {
             const labelIndex = context.dataIndex;
-            return `${sortedLabels[labelIndex]}: ${sortedValues[labelIndex]}`;
+            const total = sortedValues.reduce((acc, val) => acc + val, 0);
+            const percentage = ((sortedValues[labelIndex] / total) * 100).toFixed(2);
+            return `${sortedLabels[labelIndex]}: ${sortedValues[labelIndex]} (${percentage}%)`;
           },
         },
       },


### PR DESCRIPTION
Adds a percentage label so that hovering over the pie chart shows 
```
ticker: value (percentage of total portfolio)
```