### PR TITLE
Define API Boundary and Switch to 1 Ticker API 

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -20,7 +20,7 @@ app.set('trust proxy', 1);
 app.use(cors());
 
 // Routes
-app.use('/api', require('./routes/stocks'));
+app.use('/getStockPrice', require('./routes/getStockPrice'));
 
 // Start server
 app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/server/routes/getStockPrice.js
+++ b/server/routes/getStockPrice.js
@@ -60,7 +60,7 @@ async function fetchTickerData(ticker) {
 // API takes in as inputs a required query parameter of tickers
 //  ticker: case sensitive stock ticker string to get price for
 // returns a json object of { ticker, close, date }
-router.get('/', cache('1 minute'), async (req, res) => {
+router.get('/', cache('6 hour'), async (req, res) => {
   try {
     // parse out the ticker parameter from the request
     const reqParams = url.parse(req.url, true).query;

--- a/server/routes/stocks.js
+++ b/server/routes/stocks.js
@@ -12,26 +12,64 @@ const { API_KEY_VALUE } = process.env;
 
 const cache = apicache.middleware;
 
-router.get('/', cache('30 minute'), async (req, res) => {
+// takes in response.data of the external api, and returns
+// an object containing {ticker: {ticker, close, date}}
+function formatExternalApiResponse(ticker, data) {
+  return { [ticker]: { ticker, close: data.close, date: data.timestamp } };
+}
+
+// Function to fetch data for a single ticker
+async function fetchTickerData(ticker) {
   try {
-    const reqParams = url.parse(req.url, true).query;
     const apiParams = new URLSearchParams({
       interval: '5min',
       function: 'TIME_SERIES_INTRADAY',
       extended_hours: 'false',
+      symbol: ticker,
       [API_KEY_NAME]: API_KEY_VALUE,
-      ...reqParams,
     });
 
-    const apiRes = await needle('get', `${API_BASE_URL}?${apiParams}`);
-    const data = apiRes.body;
+    const response = await needle('get', `${API_BASE_URL}?${apiParams}`);
 
     if (process.env.NODE_ENV !== 'production') {
       console.log(`REQUEST: ${API_BASE_URL}?${apiParams}`);
-      console.log('RETURNED', data);
+      console.log('RETURNED', response.data);
     }
 
-    res.status(200).json(data);
+    // Return {ticker -> {ticker, close, date}}
+    return formatExternalApiResponse(ticker, response.data);
+  } catch (error) {
+    // Handle errors, such as if the external API returns an error
+    console.error(`Failed to fetch data for ${ticker}: ${error.message}`);
+    return null;
+  }
+}
+
+// API takes in as inputs a required query parameter of tickers
+//  tickers: list of case sensitive stock tickers to look up
+//    duplicates are allowed, but results will be collapsed for each of them
+//  returns a json map containing each ticker as the key which maps to a
+//    closing cost, and a corresponding date at which the cost was taken at
+router.get('/', cache('1 day'), async (req, res) => {
+  try {
+    // parse out the tickers parameter from the request
+    const reqParams = url.parse(req.url, true).query;
+    const tickersArray = reqParams.tickers.split(',');
+
+    // construct a promise for each ticker
+    const tickerPromises = tickersArray.map((ticker) => fetchTickerData(ticker));
+
+    // wait for each promise to resolve
+    const tickerDataResults = await Promise.all(tickerPromises);
+
+    // filter out any failed ticker results
+    const successResults = tickerDataResults.filter((result) => result !== null);
+
+    // given [{ticker: {ticker, close, date}} ... ], I want to get out a flattened
+    // map of { ticker -> {ticker, close, date}, ....}, and we can use the spread operator
+    const formattedData = successResults.reduce((acc, result) => ({ ...acc, ...result }), {});
+
+    res.status(200).json(formattedData);
   } catch (error) {
     res.status(500).json({ error });
   }

--- a/src/api/stock_api.jsx
+++ b/src/api/stock_api.jsx
@@ -23,10 +23,13 @@ const fetchStockPrices = async (stocks) => {
     const tickerPromises = stocks.map((stock) => fetchStockPrice(stock.ticker));
     const tickerResults = await Promise.all(tickerPromises);
 
-    const stockData = tickerResults.reduce((acc, { ticker, close, date }) => {
-      if (ticker && close && date) {
-        acc[ticker] = { close, date };
-      }
+    // filter only for successes
+    const successfulResults = tickerResults.filter(
+      (result) => result !== null && result.error === null,
+    );
+
+    const stockData = successfulResults.reduce((acc, { ticker, close, date }) => {
+      acc[ticker] = { close, date };
       return acc;
     }, {});
 

--- a/src/api/stock_api.jsx
+++ b/src/api/stock_api.jsx
@@ -1,5 +1,4 @@
-// const FETCH_STOCK_API = 'https://qiufolio.onrender.com/api';
-const FETCH_STOCK_API = 'http://localhost:5000/getStockPrice';
+const FETCH_STOCK_API = 'https://qiufolio.onrender.com/getStockPrice';
 
 // returns a json { ticker, close, date } from the api
 const fetchStockPrice = async (ticker) => {

--- a/src/api/stock_api.jsx
+++ b/src/api/stock_api.jsx
@@ -1,4 +1,5 @@
-const FETCH_STOCK_API = 'https://qiufolio.onrender.com/api';
+// const FETCH_STOCK_API = 'https://qiufolio.onrender.com/api';
+const FETCH_STOCK_API = 'http://localhost:5000/api';
 
 // Args: Stocks is an array of stock objects where
 // stocks has the interface of having a ticker: string field
@@ -11,9 +12,11 @@ const fetchStockPrices = async (stocks) => {
   // pass all tickers into the fetch stock api served by our proxy
   // so we should see something like <url>/api?tickers=voo,v,mc...
   const response = await fetch(`${FETCH_STOCK_API}?tickers=${tickers.join(',')}`);
+  console.log(`${FETCH_STOCK_API}?tickers=${tickers.join(',')}`);
+  const data = await response.json();
 
   // this is returned as { ticker: {ticker, close, date}}
-  return response;
+  return data;
 };
 
 export default fetchStockPrices;

--- a/src/api/stock_api.jsx
+++ b/src/api/stock_api.jsx
@@ -1,40 +1,19 @@
-const METADATA_KEY = 'Meta Data';
-const LATEST_REFRESH_KEY = '3. Last Refreshed';
-const TIME_SERIES_KEY = 'Time Series (5min)';
-const CLOSE_VALUE_KEY = '4. close';
+const FETCH_STOCK_API = 'https://qiufolio.onrender.com/api';
 
-const fetchStockPrice = async (ticker) => {
-  try {
-  // Make API request to get stock prices
-  // TODO: Once the server is hosted, swap out the endpoint from localhost
-    const stockApiEndpoint = `http://localhost:5000/api?symbol=${ticker}`;
-    const response = await fetch(stockApiEndpoint);
-    const apiData = await response.json();
-    const lastRefreshed = apiData[METADATA_KEY][LATEST_REFRESH_KEY];
-    const timeSeries = apiData[TIME_SERIES_KEY];
-    const latestData = timeSeries[lastRefreshed];
-    const lastValue = latestData[CLOSE_VALUE_KEY];
-    console.log(ticker, lastValue);
-    const parsedValueToDecimalPoints = parseFloat(parseFloat(lastValue).toFixed(2));
-
-    // Parse the value to a float and specify two decimal places
-    return parsedValueToDecimalPoints;
-  } catch (error) {
-    return 0;
-  }
-};
-
+// Args: Stocks is an array of stock objects where
+// stocks has the interface of having a ticker: string field
+// Returns a map containing {
+//   ticker: map{close: int, date: Date }
+// }
 const fetchStockPrices = async (stocks) => {
-  const responses = await Promise.all(
-    stocks.map((stock) => fetchStockPrice(stock.ticker)),
-  );
+  const tickers = stocks.map((stock) => stock.ticker);
 
-  const allData = await Promise.all(
-    responses.map((value, index) => ({ [stocks[index].ticker]: value })),
-  );
-  // Process JSON data here and update state
-  const stockPricesMap = allData.reduce((acc, obj) => ({ ...acc, ...obj }), {});
-  return stockPricesMap;
+  // pass all tickers into the fetch stock api served by our proxy
+  // so we should see something like <url>/api?tickers=voo,v,mc...
+  const response = await fetch(`${FETCH_STOCK_API}?tickers=${tickers.join(',')}`);
+
+  // this is returned as { ticker: {ticker, close, date}}
+  return response;
 };
 
 export default fetchStockPrices;

--- a/src/components/Overview.jsx
+++ b/src/components/Overview.jsx
@@ -29,6 +29,7 @@ function Overview() {
         // essentially tracking the latest value
 
         // Update the stocks state with the latest prices
+        console.log(latestStockPrices);
         const newStockState = stocks.map((stock) => ({
           ...stock,
           value: latestStockPrices[stock.ticker].close || stock.value,

--- a/src/components/Overview.jsx
+++ b/src/components/Overview.jsx
@@ -30,10 +30,15 @@ function Overview() {
 
         // Update the stocks state with the latest prices
         console.log(latestStockPrices);
-        const newStockState = stocks.map((stock) => ({
-          ...stock,
-          value: latestStockPrices[stock.ticker].close || stock.value,
-        }));
+        const newStockState = stocks.map((stock) => {
+          // keep the rest of the stock fields the same but update if we get a new value
+          const newPrice = latestStockPrices[stock.ticker]?.close;
+          return {
+            ...stock,
+            // Keep the old value if newPrice is undefined
+            value: newPrice !== undefined ? newPrice : stock.value,
+          };
+        });
         setStocks(newStockState);
       } catch (error) {
         console.error('Error fetching stock prices:', error);

--- a/src/components/Overview.jsx
+++ b/src/components/Overview.jsx
@@ -21,6 +21,7 @@ function Overview() {
     // Call fetchStockPrices function when component mounts
     const fetchData = async () => {
       try {
+        // {ticker -> {ticker, close, date}}
         const latestStockPrices = await fetchStockPrices(stocks);
 
         // TODO? Write latestStockPrices to a file so we can
@@ -30,7 +31,7 @@ function Overview() {
         // Update the stocks state with the latest prices
         const newStockState = stocks.map((stock) => ({
           ...stock,
-          value: latestStockPrices[stock.ticker] || stock.value,
+          value: latestStockPrices[stock.ticker].close || stock.value,
         }));
         setStocks(newStockState);
       } catch (error) {


### PR DESCRIPTION
Establish that our backend takes in 1 ticker, and returns a json containing the { ticker, close, date }. 
Then we handle this and update prices. We did it this way so we can cache each ticker's response individually rather than have it be a group query.