### PR TITLE
Increase Rate Limit

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -11,7 +11,7 @@ const app = express();
 // Rate Limiting
 const limiter = rateLimit({
   windowMs: 10 * 60 * 1000, // 10 minutes
-  max: 5, // 5 requests max
+  max: 10, // 5 requests max
 });
 app.use(limiter);
 app.set('trust proxy', 1);

--- a/server/index.js
+++ b/server/index.js
@@ -11,7 +11,7 @@ const app = express();
 // Rate Limiting
 const limiter = rateLimit({
   windowMs: 10 * 60 * 1000, // 10 minutes
-  max: 10, // 5 requests max
+  max: 10, // max 10 requests in those 10 minutes
 });
 app.use(limiter);
 app.set('trust proxy', 1);


### PR DESCRIPTION
Now that we call the API for each individual ticker, we should increase the timeout. Results are still cached 