### PR TITLE
Filter Logic Fix 

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -11,7 +11,7 @@ const app = express();
 // Rate Limiting
 const limiter = rateLimit({
   windowMs: 10 * 60 * 1000, // 10 minutes
-  max: 10, // max 10 requests in those 10 minutes
+  max: 60, // max 10 requests in those 10 minutes
 });
 app.use(limiter);
 app.set('trust proxy', 1);

--- a/src/api/stock_api.jsx
+++ b/src/api/stock_api.jsx
@@ -24,13 +24,14 @@ const fetchStockPrices = async (stocks) => {
 
     // filter only for successes
     const successfulResults = tickerResults.filter(
-      (result) => result !== null && result.error === null,
+      (result) => result !== null && !('error' in result),
     );
 
     const stockData = successfulResults.reduce((acc, { ticker, close, date }) => {
       acc[ticker] = { close, date };
       return acc;
     }, {});
+    console.log('stockData', stockData);
 
     return stockData;
   } catch (error) {

--- a/src/components/Overview.jsx
+++ b/src/components/Overview.jsx
@@ -29,7 +29,6 @@ function Overview() {
         // essentially tracking the latest value
 
         // Update the stocks state with the latest prices
-        console.log(latestStockPrices);
         const newStockState = stocks.map((stock) => {
           // keep the rest of the stock fields the same but update if we get a new value
           const newPrice = latestStockPrices[stock.ticker]?.close;


### PR DESCRIPTION
The logic previously to filter for successful logics was buggy which caused successful responses to get dropped.
Also updates some console.log statements and increases the rate limit further. 