### PR TITLE
Add Cron Job To Periodically Update DB with Latest Stock Prices

### DIFF
--- a/server/cron/cron.js
+++ b/server/cron/cron.js
@@ -1,0 +1,40 @@
+const cron = require('node-cron');
+
+const { fetchStaleStocksFromDb, fetchAndUpdateStockData } = require('./helpers');
+
+// Normally, we would do this if we had a permanent
+// web service always running, but since render spins down
+// instances after 15 min, this cron won't run
+// so instead, we should run a frequent cron that runs
+// whenever the service does spin up, once it does
+// spin up, we should check the db and only run whenever
+// the last fetched date stamp is past some time
+
+// trigger 9am and 12pm, Monday through Friday
+// const cronSchedule = '0 9,12 * * 1-5';
+
+// run every 15 minutes instead but do it on a stale basis
+const CRON_SCHEDULE = '*/15 * * * *';
+
+const cronJob = cron.schedule(
+  CRON_SCHEDULE,
+  async () => {
+    // Query for all stocks that are 6 hours stale
+    try {
+      const tickers = await fetchStaleStocksFromDb();
+      console.log('Stale stocks:', tickers);
+
+      const updates = await fetchAndUpdateStockData(tickers);
+      console.log(`Finished cron with the following successful updates: ${updates.length}`);
+    } catch (error) {
+      console.log('failed to get stock data', error);
+    }
+  },
+  {
+    name: 'qiufolio-cron',
+    scheduled: false,
+    timezone: 'America/Los_Angeles',
+  },
+);
+
+module.exports = cronJob;

--- a/server/cron/helpers.js
+++ b/server/cron/helpers.js
@@ -1,0 +1,92 @@
+const needle = require('needle');
+const itemsPool = require('../db/dbConfig');
+
+const STALE_TIME_THRESHOLD_MS = 6 * 60 * 60 * 1000;
+
+// Env vars
+const { API_BASE_URL, API_KEY_NAME, API_KEY_VALUE } = process.env;
+
+const METADATA_KEY = 'Meta Data';
+const LATEST_REFRESH_KEY = '3. Last Refreshed';
+const TIME_SERIES_KEY = 'Time Series (5min)';
+const CLOSE_VALUE_KEY = '4. close';
+
+async function fetchStaleStocksFromDb() {
+  const currentTime = new Date();
+  const sixHoursAgo = new Date(currentTime.getTime() - STALE_TIME_THRESHOLD_MS);
+
+  // Fetch and query for the top 5 most stale stocks, due to API limits, we can't
+  // query the API too much, but we can guarantee that eventually we'll get everything
+  // not ideal, but it's ok.
+  try {
+    const queryResult = await itemsPool.query(`
+        SELECT ticker 
+        FROM stocks 
+        WHERE last_price_update < $1 
+        ORDER BY last_price_update ASC 
+        LIMIT 5
+    `, [sixHoursAgo]);
+
+    return queryResult.rows.map((row) => row.ticker);
+  } catch (error) {
+    console.log('Failed to fetch stale stocks from the database:', error);
+    return [];
+  }
+}
+
+// takes in ticker, and response.data of the external api, and returns
+// an object containing { ticker, close, date }
+function formatExternalApiResponse(ticker, data) {
+  const lastRefreshed = data[METADATA_KEY][LATEST_REFRESH_KEY];
+  const timeSeries = data[TIME_SERIES_KEY];
+  const latestData = timeSeries[lastRefreshed];
+  const lastValue = latestData[CLOSE_VALUE_KEY];
+  const parsedValueToDecimalPoints = parseFloat(parseFloat(lastValue).toFixed(2));
+
+  // Parse the value to a float and specify two decimal places
+  return { ticker, close: parsedValueToDecimalPoints, date: lastRefreshed };
+}
+
+// Function to fetch data for a single ticker
+async function fetchTickerDataFromApi(ticker) {
+  try {
+    const apiParams = new URLSearchParams({
+      interval: '5min',
+      function: 'TIME_SERIES_INTRADAY',
+      extended_hours: 'false',
+      symbol: ticker,
+      [API_KEY_NAME]: API_KEY_VALUE,
+    });
+
+    console.log(`Making API Request for ${ticker}`);
+    const response = await needle('get', `${API_BASE_URL}?${apiParams}`);
+
+    // Return {ticker, close, date}
+    return formatExternalApiResponse(ticker, response.body);
+  } catch (error) {
+    // Handle errors, such as if the external API returns an error
+    console.error(`Failed to fetch data for ${ticker}: ${error.message}`);
+    return null;
+  }
+}
+
+async function updateDbWithNewStockData({ ticker, close }) {
+  const currentTime = new Date();
+  console.log(`Updating DB with ${ticker} ${close} ${currentTime}`);
+  return itemsPool.query(
+    'UPDATE stocks SET last_price = $1, last_price_update = $2 WHERE ticker = $3',
+    [close, currentTime, ticker],
+  );
+}
+
+async function fetchAndUpdateStockData(tickers) {
+  const fetchPromises = tickers.map((ticker) => fetchTickerDataFromApi(ticker));
+  const apiResults = await Promise.all(fetchPromises);
+
+  const successfulResults = apiResults.filter((result) => result !== null && !('error' in result));
+
+  const updatePromises = successfulResults.map((res) => updateDbWithNewStockData(res));
+  return Promise.all(updatePromises);
+}
+
+module.exports = { fetchStaleStocksFromDb, fetchAndUpdateStockData };

--- a/server/index.js
+++ b/server/index.js
@@ -1,8 +1,9 @@
+require('dotenv').config();
+
 const express = require('express');
 const cors = require('cors');
 const rateLimit = require('express-rate-limit');
-
-require('dotenv').config();
+const cronJob = require('./cron/cron');
 
 const PORT = process.env.PORT || 5000;
 
@@ -21,6 +22,10 @@ app.use(cors());
 
 // Routes
 app.use('/getStockPrice', require('./routes/getStockPrice'));
+
+// Start Cron Job
+console.log('Starting cron!');
+cronJob.start();
 
 // Start server
 app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -15,6 +15,7 @@
         "express": "^4.18.3",
         "express-rate-limit": "^7.2.0",
         "needle": "^3.3.1",
+        "node-cron": "^3.0.3",
         "pg": "^8.11.3"
       }
     },
@@ -539,6 +540,17 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-cron": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -909,6 +921,14 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/server/package.json
+++ b/server/package.json
@@ -16,6 +16,7 @@
     "express": "^4.18.3",
     "express-rate-limit": "^7.2.0",
     "needle": "^3.3.1",
+    "node-cron": "^3.0.3",
     "pg": "^8.11.3"
   }
 }

--- a/server/routes/getStockPrice.js
+++ b/server/routes/getStockPrice.js
@@ -8,7 +8,7 @@ const router = express.Router();
 const cache = apicache.middleware;
 
 // Function to fetch data for a single ticker
-async function fetchTickerData(ticker) {
+async function fetchTickerDataFromDB(ticker) {
   // TODO: qiujames is set for now, eventually we will have users
   // TODO: eventually include the quantity
   try {
@@ -40,7 +40,7 @@ router.get('/', cache('30 minutes'), async (req, res) => {
     const { ticker } = reqParams;
 
     // fetch data for the single ticker
-    const tickerData = await fetchTickerData(ticker);
+    const tickerData = await fetchTickerDataFromDB(ticker);
 
     if (!tickerData) {
       return res.status(404).json({ error: 'Ticker not found or data not available' });


### PR DESCRIPTION
Adds a cron that runs every 15 minutes that fetches the stalest stock entries in the database, hits an endpoint to query the stock data, and then updates the database. This means that eventually, the front end will get this data once it queries the database.