### PR TITLE
Add Ticker Label to Pie Chart

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@vitejs/plugin-react": "^4.2.1",
         "chart.js": "^4.4.2",
+        "chartjs-plugin-datalabels": "^2.2.0",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
         "react-chartjs-2": "^5.2.0",
@@ -1564,6 +1565,14 @@
       },
       "engines": {
         "pnpm": ">=8"
+      }
+    },
+    "node_modules/chartjs-plugin-datalabels": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chartjs-plugin-datalabels/-/chartjs-plugin-datalabels-2.2.0.tgz",
+      "integrity": "sha512-14ZU30lH7n89oq+A4bWaJPnAG8a7ZTk7dKf48YAzMvJjQtjrgg5Dpk9f+LbjCF6bpx3RAGTeL13IXpKQYyRvlw==",
+      "peerDependencies": {
+        "chart.js": ">=3.0.0"
       }
     },
     "node_modules/color-convert": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@vitejs/plugin-react": "^4.2.1",
     "chart.js": "^4.4.2",
+    "chartjs-plugin-datalabels": "^2.2.0",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-chartjs-2": "^5.2.0",

--- a/src/components/PieChart.jsx
+++ b/src/components/PieChart.jsx
@@ -4,18 +4,24 @@ import {
   ArcElement, Chart as ChartJS, Colors, Legend, Tooltip,
 } from 'chart.js';
 import PropTypes from 'prop-types';
+import ChartDataLabels from 'chartjs-plugin-datalabels';
 import getStockValue from '../utils/TotalStockValueUtil';
 
 ChartJS.register(ArcElement);
 ChartJS.register(Colors);
 ChartJS.register(Tooltip);
 ChartJS.register(Legend);
+ChartJS.register(ChartDataLabels);
+
+const PERCENTAGE_LABEL_THRESHOLD = 8;
 
 function PieChart({ stocks }) {
   const sortedStocks = stocks.slice().sort((a, b) => getStockValue(b) - getStockValue(a));
   // Extracting labels and data for the chart
   const sortedLabels = sortedStocks.map((stock) => stock.ticker);
   const sortedValues = sortedStocks.map((stock) => getStockValue(stock));
+
+  const total = sortedValues.reduce((acc, val) => acc + val, 0);
 
   const data = {
     labels: sortedLabels,
@@ -33,7 +39,6 @@ function PieChart({ stocks }) {
         callbacks: {
           label(context) {
             const labelIndex = context.dataIndex;
-            const total = sortedValues.reduce((acc, val) => acc + val, 0);
             const percentage = ((sortedValues[labelIndex] / total) * 100).toFixed(2);
             return `${sortedLabels[labelIndex]}: ${sortedValues[labelIndex]} (${percentage}%)`;
           },
@@ -46,6 +51,18 @@ function PieChart({ stocks }) {
       },
       colors: {
         enabled: true,
+      },
+      datalabels: {
+        display(context) {
+          const labelIndex = context.dataIndex;
+          const percentage = ((sortedValues[labelIndex] / total) * 100).toFixed(2);
+          return percentage > PERCENTAGE_LABEL_THRESHOLD;
+        },
+        formatter(_, context) {
+          const labelIndex = context.dataIndex;
+          return sortedLabels[labelIndex];
+        },
+        color: 'black',
       },
     },
   };


### PR DESCRIPTION
![Screenshot 2024-03-17 at 9 42 35 PM](https://github.com/qiujames/qiufolios/assets/52264658/e6525a81-44b3-45fb-9fc7-afb6823e417e)

Adds the ticker as a label to the pie chart if the pie chart slice is sufficiently large enough.
Colors is a little confusing since they change