### PR TITLE
Swap API

### DIFF
--- a/server/cron/api.js
+++ b/server/cron/api.js
@@ -3,31 +3,19 @@ const needle = require('needle');
 // Env vars
 const { API_BASE_URL, API_KEY_NAME, API_KEY_VALUE } = process.env;
 
-const METADATA_KEY = 'Meta Data';
-const LATEST_REFRESH_KEY = '3. Last Refreshed';
-const TIME_SERIES_KEY = 'Time Series (5min)';
-const CLOSE_VALUE_KEY = '4. close';
-
 // takes in ticker, and response.data of the external api, and returns
 // an object containing { ticker, close, date }
 function formatExternalApiResponse(ticker, data) {
-  const lastRefreshed = data[METADATA_KEY][LATEST_REFRESH_KEY];
-  const timeSeries = data[TIME_SERIES_KEY];
-  const latestData = timeSeries[lastRefreshed];
-  const lastValue = latestData[CLOSE_VALUE_KEY];
-  const parsedValueToDecimalPoints = parseFloat(parseFloat(lastValue).toFixed(2));
-
-  // Parse the value to a float and specify two decimal places
-  return { ticker, close: parsedValueToDecimalPoints, date: lastRefreshed };
+  const close = data.c;
+  const dateUnixTimestamp = data.t;
+  const date = new Date(dateUnixTimestamp * 1000);
+  return { ticker, close, date };
 }
 
 // Function to fetch data for a single ticker
 async function fetchTickerDataFromApi(ticker) {
   try {
     const apiParams = new URLSearchParams({
-      interval: '5min',
-      function: 'TIME_SERIES_INTRADAY',
-      extended_hours: 'false',
       symbol: ticker,
       [API_KEY_NAME]: API_KEY_VALUE,
     });

--- a/server/cron/api.js
+++ b/server/cron/api.js
@@ -1,0 +1,47 @@
+const needle = require('needle');
+
+// Env vars
+const { API_BASE_URL, API_KEY_NAME, API_KEY_VALUE } = process.env;
+
+const METADATA_KEY = 'Meta Data';
+const LATEST_REFRESH_KEY = '3. Last Refreshed';
+const TIME_SERIES_KEY = 'Time Series (5min)';
+const CLOSE_VALUE_KEY = '4. close';
+
+// takes in ticker, and response.data of the external api, and returns
+// an object containing { ticker, close, date }
+function formatExternalApiResponse(ticker, data) {
+  const lastRefreshed = data[METADATA_KEY][LATEST_REFRESH_KEY];
+  const timeSeries = data[TIME_SERIES_KEY];
+  const latestData = timeSeries[lastRefreshed];
+  const lastValue = latestData[CLOSE_VALUE_KEY];
+  const parsedValueToDecimalPoints = parseFloat(parseFloat(lastValue).toFixed(2));
+
+  // Parse the value to a float and specify two decimal places
+  return { ticker, close: parsedValueToDecimalPoints, date: lastRefreshed };
+}
+
+// Function to fetch data for a single ticker
+async function fetchTickerDataFromApi(ticker) {
+  try {
+    const apiParams = new URLSearchParams({
+      interval: '5min',
+      function: 'TIME_SERIES_INTRADAY',
+      extended_hours: 'false',
+      symbol: ticker,
+      [API_KEY_NAME]: API_KEY_VALUE,
+    });
+
+    console.log(`Making API Request for ${ticker}`);
+    const response = await needle('get', `${API_BASE_URL}?${apiParams}`);
+
+    // Return {ticker, close, date}
+    return formatExternalApiResponse(ticker, response.body);
+  } catch (error) {
+    // Handle errors, such as if the external API returns an error
+    console.error(`Failed to fetch data for ${ticker}: ${error.message}`);
+    return null;
+  }
+}
+
+module.exports = fetchTickerDataFromApi;

--- a/server/cron/cron.js
+++ b/server/cron/cron.js
@@ -14,7 +14,7 @@ const { fetchStaleStocksFromDb, fetchAndUpdateStockData } = require('./helpers')
 // const cronSchedule = '0 9,12 * * 1-5';
 
 // run every 15 minutes instead but do it on a stale basis
-const CRON_SCHEDULE = '*/15 * * * *';
+const CRON_SCHEDULE = '*/15 * * * * *';
 
 const cronJob = cron.schedule(
   CRON_SCHEDULE,

--- a/server/cron/cron.js
+++ b/server/cron/cron.js
@@ -13,8 +13,8 @@ const { fetchStaleStocksFromDb, fetchAndUpdateStockData } = require('./helpers')
 // trigger 9am and 12pm, Monday through Friday
 // const cronSchedule = '0 9,12 * * 1-5';
 
-// run every 15 minutes instead but do it on a stale basis
-const CRON_SCHEDULE = '*/15 * * * * *';
+// run every 1 minutes instead but do it on a stale basis
+const CRON_SCHEDULE = '*/1 * * * *';
 
 const cronJob = cron.schedule(
   CRON_SCHEDULE,

--- a/server/cron/helpers.js
+++ b/server/cron/helpers.js
@@ -1,15 +1,7 @@
-const needle = require('needle');
 const itemsPool = require('../db/dbConfig');
+const fetchTickerDataFromApi = require('./api');
 
 const STALE_TIME_THRESHOLD_MS = 6 * 60 * 60 * 1000;
-
-// Env vars
-const { API_BASE_URL, API_KEY_NAME, API_KEY_VALUE } = process.env;
-
-const METADATA_KEY = 'Meta Data';
-const LATEST_REFRESH_KEY = '3. Last Refreshed';
-const TIME_SERIES_KEY = 'Time Series (5min)';
-const CLOSE_VALUE_KEY = '4. close';
 
 async function fetchStaleStocksFromDb() {
   const currentTime = new Date();
@@ -31,42 +23,6 @@ async function fetchStaleStocksFromDb() {
   } catch (error) {
     console.log('Failed to fetch stale stocks from the database:', error);
     return [];
-  }
-}
-
-// takes in ticker, and response.data of the external api, and returns
-// an object containing { ticker, close, date }
-function formatExternalApiResponse(ticker, data) {
-  const lastRefreshed = data[METADATA_KEY][LATEST_REFRESH_KEY];
-  const timeSeries = data[TIME_SERIES_KEY];
-  const latestData = timeSeries[lastRefreshed];
-  const lastValue = latestData[CLOSE_VALUE_KEY];
-  const parsedValueToDecimalPoints = parseFloat(parseFloat(lastValue).toFixed(2));
-
-  // Parse the value to a float and specify two decimal places
-  return { ticker, close: parsedValueToDecimalPoints, date: lastRefreshed };
-}
-
-// Function to fetch data for a single ticker
-async function fetchTickerDataFromApi(ticker) {
-  try {
-    const apiParams = new URLSearchParams({
-      interval: '5min',
-      function: 'TIME_SERIES_INTRADAY',
-      extended_hours: 'false',
-      symbol: ticker,
-      [API_KEY_NAME]: API_KEY_VALUE,
-    });
-
-    console.log(`Making API Request for ${ticker}`);
-    const response = await needle('get', `${API_BASE_URL}?${apiParams}`);
-
-    // Return {ticker, close, date}
-    return formatExternalApiResponse(ticker, response.body);
-  } catch (error) {
-    // Handle errors, such as if the external API returns an error
-    console.error(`Failed to fetch data for ${ticker}: ${error.message}`);
-    return null;
   }
 }
 

--- a/server/routes/getStockPrice.js
+++ b/server/routes/getStockPrice.js
@@ -13,7 +13,7 @@ async function fetchTickerDataFromDB(ticker) {
   // TODO: eventually include the quantity
   try {
     const stockData = await itemsPool.query(`
-      SELECT us.ticker AS ticker, us.quantity AS quantity, s.last_price AS close, s.last_price_update AS date
+      SELECT us.ticker AS ticker, us.quantity AS quantity, s.last_price AS close, s.last_price_timestamp AS date
       FROM user_stocks AS us
       JOIN stocks AS s ON us.ticker = s.ticker
       WHERE us.username = 'qiujames' AND us.ticker = $1;
@@ -33,7 +33,7 @@ async function fetchTickerDataFromDB(ticker) {
 // API takes in as inputs a required query parameter of tickers
 //  ticker: case sensitive stock ticker string to get price for
 // returns a json object of { ticker, close, date }
-router.get('/', cache('30 minutes'), async (req, res) => {
+router.get('/', cache('1 minutes'), async (req, res) => {
   try {
     // parse out the ticker parameter from the request
     const reqParams = url.parse(req.url, true).query;


### PR DESCRIPTION
Swaps the API provider with a more generous API free tier (25 api calls / day => 60 api calls / min).
This means, we can query the api more frequently, lower the stale threshold, and lower the cache of the overall api.

We also updated the database schema to store the last_price_timestamp and added a last_data_update_timestamp.